### PR TITLE
Implement admin sidebar document management

### DIFF
--- a/client/src/components/Documents/Editor.jsx
+++ b/client/src/components/Documents/Editor.jsx
@@ -48,7 +48,7 @@ class Editor extends Component {
     this.handleTextChange = this.handleTextChange.bind(this);
     this.handleSelect = this.handleSelect.bind(this);
     this.handleUpdate = this.handleUpdate.bind(this);
-    this.concludeSaveUpdate = this.concludeSaveUpdate.bind(this);
+    this.handlePageRedirect = this.handlePageRedirect.bind(this);
     this.handleClose = this.handleClose.bind(this);
   }
 
@@ -60,7 +60,7 @@ class Editor extends Component {
    */
   handleClose(e) { // eslint-disable-line
     e.preventDefault();
-    this.concludeSaveUpdate();
+    this.handlePageRedirect();
   }
 
   /**
@@ -103,7 +103,7 @@ class Editor extends Component {
    * @returns {None} none
    * @memberof Editor
    */
-  concludeSaveUpdate() {
+  handlePageRedirect() {
     this.props.actions.editDocumentCompleted();
     browserHistory.push('/');
   }
@@ -132,7 +132,7 @@ class Editor extends Component {
         toastr.success('Document saved succesfully');
       })
       .catch(() => toastr.error('Something Went Wrong', 'Please login Again'));
-    this.concludeSaveUpdate();
+    this.handlePageRedirect();
   }
   /**
    * Funtion to handle Updating created documents
@@ -160,12 +160,12 @@ class Editor extends Component {
         }).catch(() => {
           toastr.error('Document could not be updated!');
         });
-      this.concludeSaveUpdate();
+      this.handlePageRedirect();
     } else {
       toastr.error(
         `You currently do not have edit access ${document.title}`
       );
-      this.concludeSaveUpdate();
+      this.handlePageRedirect();
     }
   }
   /**

--- a/client/src/components/admin/DocumentManager/DocumentManager.jsx
+++ b/client/src/components/admin/DocumentManager/DocumentManager.jsx
@@ -1,11 +1,33 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { browserHistory } from 'react-router';
+import { connect } from 'react-redux';
+import { Row, Col } from 'react-materialize';
+import { loadAllDocument } from '../../../actions/documentActions';
+import Nav from '../../Nav'; //eslint-disable-line
+import MainContainer from './MainContainer';
+
 
 /**
- * Replace with appropriate info on completion
  * @class DocumentManager
- * @extends {React.Component}
+ * @extends {Component}
  */
 class DocumentManager extends Component {
+  /**
+   * Hook Method
+   * @returns {none} none
+   * @memberOf DocumentManager
+   */
+  componentWillMount() {
+    if (this.props.user.roleId === 1) {
+      this.props.loadAllDocument().catch(() => {
+        browserHistory.push('/');
+      });
+    } else {
+      localStorage.removeItem('jwtToken');
+      browserHistory.push('/login');
+    }
+  }
   /**
    * @returns {Object} Jsx
    * @memberOf DocumentManager
@@ -13,10 +35,27 @@ class DocumentManager extends Component {
   render() {
     return (
       <div>
-        <h1>Inside DocumentManager Component</h1>
+        <Nav />
+        <div>
+          <Row>
+            <Col m={1} />
+            <Col m={10}>
+              <MainContainer />
+            </Col>
+            <Col m={1} />
+          </Row>
+        </div>
       </div>
     );
   }
 }
+DocumentManager.propTypes = {
+  user: PropTypes.object.isRequired,
+  loadAllDocument: PropTypes.func.isRequired
+};
+const mapStateToProps = state => ({
+  user: state.auth.user
+});
 
-export default DocumentManager;
+export default connect(mapStateToProps,
+  { loadAllDocument })(DocumentManager);

--- a/client/src/components/admin/DocumentManager/DocumentTable.jsx
+++ b/client/src/components/admin/DocumentManager/DocumentTable.jsx
@@ -1,22 +1,299 @@
-import React, { Component } from 'react';
+import React, { PropTypes, Component } from 'react';
+import {
+  Table,
+  TableBody,
+  TableHeader,
+  TableHeaderColumn,
+  TableRow,
+  TableRowColumn,
+  TableFooter } from 'material-ui/Table';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import SortIcon from 'material-ui/svg-icons/action/swap-vert';
+import IconButton from 'material-ui/IconButton';
+import ChevronLeft from 'material-ui/svg-icons/navigation/chevron-left';
+import ChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
+import FlatButton from 'material-ui/FlatButton';
+import { sortFunc, processTableData } from '../../../utils';
+import * as documentActions from '../../../actions/documentActions';
+
 
 /**
- * Replace with appropriate info on completion
- * @class DocumentTable
- * @extends {React.Component}
+ * @class DocTable
+ * @extends {Component}
  */
 class DocumentTable extends Component {
+  /**
+   * Creates an instance of DocTable.
+   * @param {Object} props
+   * @memberOf DocumentTable
+   */
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isAsc: true,
+      sortHeader: null,
+      offset: 0,
+      limit: props.limit,
+      page: [],
+      showButtons: false
+    };
+
+    this.paginate = this.paginate.bind(this);
+    this.paginateBack = this.paginateBack.bind(this);
+    this.paginateForward = this.paginateForward.bind(this);
+    this.sortByColumn = this.sortByColumn.bind(this);
+    this.handleEdit = this.handleEdit.bind(this);
+    // this.handleSelectedDocument = this.handleSelectedDocument.bind(this);
+  }
+
+  /**
+   * Hook Method
+   * @param {Object} nextProps
+   * @returns {none} updates state before component mounts
+   * @memberOf DocumentTable
+   */
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      data: nextProps.data,
+      page: nextProps.data
+        ? nextProps.data.slice(this.state.offset, nextProps.limit)
+        :
+        [],
+    });
+  }
+
+  /**
+   * Function that responds to click events to return sorted data
+   * @param {Object} e: browser event
+   * @returns {Object} updated state of sorted data
+   * @memberOf DocumentTable
+   */
+  sortByColumn(e) {
+    e.preventDefault();
+    const sortHeader = e.target.id;
+    if (sortHeader.length < 1) {
+      return;
+    }
+    const { data, limit } = this.state;
+    const isAsc = this.state.sortHeader === sortHeader ?
+      !this.state.isAsc : true;
+    const sortedData = data.sort((a, b) => sortFunc(a, b, sortHeader));
+    if (!isAsc) {
+      sortedData.reverse();
+    }
+    this.setState({
+      page: sortedData.slice(0, limit),
+      data: sortedData,
+      sortHeader,
+      offset: 0,
+      isAsc
+    });
+  }
+  /**
+   * Function that handles deletion of documents
+   * @param {Number} id - userId
+   * @param {Function} callback - to delete user after prompt
+   * @returns {Function} callback
+   * @memberOf DocumentTable
+   */
+  handleDelete(id, callback) { //eslint-disable-line
+    swal({  //eslint-disable-line
+      title: 'Are you sure?',
+      text: 'This Document will be totally deleted!',
+      type: 'warning',
+      showCancelButton: true,
+      confirmButtonColor: '#DD6B55',
+      confirmButtonText: 'Yes, delete it!',
+      closeOnConfirm: true
+    },
+    () => {
+      callback(id);
+    });
+  }
+
+  /**
+   * Function to handle Updates on document
+   * @param {Object} document - userId
+   * @returns {Function} callback
+   * @memberOf DocumentTable
+   */
+  handleEdit(document) {
+    const formattedDocument = {
+      title: document.title,
+      content: document.content,
+      access: document.access,
+      id: document.id,
+      ownerId: document.ownerId,
+      date: document.date
+    };
+    this.props.actions.editDocument(formattedDocument);
+    this.context.router.push('/editor');
+  }
+
+  /**
+   * Function that paginates data in an array
+   * @param {Number} offset
+   * @param {Number} limit
+   *@returns {none} updates state with new paginated data
+   * @memberOf DocumentTable
+   */
+  paginate(offset, limit) {
+    this.setState({
+      page: this.state.data.slice(offset, offset + limit),
+      offset,
+    });
+  }
+
+  /**
+   * Functions to move to a previous page
+   * @param {none} none
+   * @returns {none} none
+   * @memberOf DocumentTable
+   */
+  paginateBack() {
+    const { offset, limit } = this.state;
+    this.paginate(offset - limit, limit);
+  }
+
+  /**
+   * Functions to move to a new page
+   * @param {none} none
+   * @returns {none} none
+   * @memberOf DocumentTable
+   */
+  paginateForward() {
+    const { offset, limit } = this.state;
+    this.paginate(offset + limit, limit);
+  }
+
   /**
    * @returns {Object} Jsx
    * @memberOf DocumentTable
    */
   render() {
+    const { total, tableHeaders } = this.props;
+    const { offset, limit, page } = this.state;
+    const processedData = processTableData(page);
+
     return (
-      <div>
-        <h1>Inside DocumentTable Component</h1>
-      </div>
+      <Table className="table" displaySelectAll={false}>
+        <TableHeader displaySelectAll={false}>
+          <TableRow>
+            { tableHeaders && tableHeaders.map((header, index) => (
+              <TableHeaderColumn key={index} >
+                <div className="rowAlign">
+                  { header.alias }
+                  { header.sortable &&
+                    <SortIcon
+                      id={header.dataAlias}
+                      className="sortIcon"
+                      onMouseUp={this.sortByColumn}
+                    />
+                  }
+                </div>
+              </TableHeaderColumn>
+            )) }
+          </TableRow>
+        </TableHeader>
+        <TableBody
+          stripedRows
+        >
+          {processedData.map((row, index) => (
+            <TableRow key={`${index} ${row.id}`}>
+              <TableRowColumn key={`${row.id} ${row.id}`}>
+                {row.id}
+              </TableRowColumn>
+              <TableRowColumn key={`${row.id} ${row.title}`}>
+                {row.title}
+              </TableRowColumn>
+              <TableRowColumn key={`${row.id} ${row.access}`}>
+                {row.access}
+              </TableRowColumn>
+              <TableRowColumn key={`${row.id} ${row.ownerRoleId}`}>
+                {row.ownerRoleId === 1 ? 'Admin' : 'Regular'}
+              </TableRowColumn>
+              <TableRowColumn key={`${row.id} ${row.ownerRoleId}`}>
+                <FlatButton
+                  key={`${index}flat${row.id}`}
+                  label="Delete"
+                  secondary
+                  onTouchTap={
+                    () => {
+                      this.handleDelete(
+                        row.id,
+                        this.props.actions.deleteDocumentById
+                      );
+                    }
+                  }
+                />
+              </TableRowColumn>
+              <TableRowColumn key={`${row.id} ${row.ownerRoleId}`}>
+                <FlatButton
+                  key={`${index}flat${row.id}`}  // eslint-disable-line
+                  label="Edit"
+                  secondary
+                  onTouchTap={
+                    () => {
+                      this.handleEdit(row);
+                    }
+                  }
+                />
+              </TableRowColumn>
+            </TableRow>
+          ))
+          }
+        </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TableRowColumn>
+              <div className="footerControls">
+                { `${Math.min((offset + 1), total)}
+                - ${Math.min((offset + limit), total)} of ${total}` }
+                <IconButton
+                  disabled={offset === 0}
+                  onClick={this.paginateBack}
+                >
+                  <ChevronLeft />
+                </IconButton>
+                <IconButton
+                  disabled={offset + limit >= total}
+                  onClick={this.paginateForward}
+                >
+                  <ChevronRight />
+                </IconButton>
+              </div>
+            </TableRowColumn>
+          </TableRow>
+        </TableFooter>
+      </Table>
     );
   }
 }
 
-export default DocumentTable;
+DocumentTable.propTypes = {
+  tableHeaders: PropTypes.array.isRequired,
+  data: PropTypes.array.isRequired,
+  total: PropTypes.number.isRequired,
+  limit: PropTypes.number.isRequired,
+  actions: PropTypes.object.isRequired
+};
+
+DocumentTable.contextTypes = {
+  router: PropTypes.object
+};
+
+const mapStateToProps = (state) => {
+  const { documents } = state.manageDocuments;
+  return {
+    data: documents,
+    total: documents.length
+  };
+};
+
+const mapDispatchToProps = dispatch => ({
+  actions: bindActionCreators(documentActions, dispatch)
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(DocumentTable);

--- a/client/src/components/admin/DocumentManager/MainContainer.jsx
+++ b/client/src/components/admin/DocumentManager/MainContainer.jsx
@@ -1,20 +1,29 @@
 import React, { Component } from 'react';
+import DocumentTable from './DocumentTable';
 
 /**
- * Replace with appropriate info on completion
- * @class MainContainer
- * @extends {React.Component}
+ * @class Container
+ * @extends {Component}
  */
 class MainContainer extends Component {
   /**
    * @returns {Object} Jsx
-   * @memberOf MainContainer
+   * @memberOf Container
    */
   render() {
+    const tableHeaders = [
+      { alias: 'ID', sortable: true, dataAlias: 'id' },
+      { alias: 'Title', sortable: true, dataAlias: 'title' },
+      { alias: 'Access', sortable: true, dataAlias: 'access' },
+      { alias: 'Role', sortable: false, dataAlias: 'ownerRoleId' },
+      { alias: '', sortable: false, dataAlias: 'ownerId' },
+      { alias: '', sortable: false, dataAlias: 'ownerId' }
+    ];
     return (
-      <div>
-        <h1>Inside MainContainer Component</h1>
-      </div>
+      <DocumentTable
+        tableHeaders={tableHeaders}
+        limit={8}
+      />
     );
   }
 }

--- a/client/src/utils/index.js
+++ b/client/src/utils/index.js
@@ -1,0 +1,55 @@
+/**
+ * Function to sort Table items
+ * @export
+ * @param {Array} a
+ * @param {Array} b
+ * @param {Integer} key
+ * @returns {Integer} length
+ */
+export function sortFunc(a, b, key) {
+  if (typeof (a[key]) === 'number') {
+    return a[key] - b[key];
+  }
+  const ax = [];
+  const bx = [];
+  a[key].replace(/(\d+)|(\D+)/g,
+    (_, $1, $2) => {
+      ax.push([$1 || Infinity, $2 || '']);
+    });
+  b[key].replace(/(\d+)|(\D+)/g,
+    (_, $1, $2) => {
+      bx.push([$1 || Infinity, $2 || '']);
+    });
+  while (ax.length && bx.length) {
+    const an = ax.shift();
+    const bn = bx.shift();
+    const nn = (an[0] - bn[0]) || an[1].localeCompare(bn[1]);
+    if (nn) return nn;
+  }
+  return ax.length - bx.length;
+}
+/**
+ * Function to sort Table items
+ * @export
+ * @param {Array} data
+ * @returns {Object} Table Items
+ */
+export function processTableData(data) {
+  if (data.constructor === Array) {
+    return data.map((obj) => {
+      const newObj = {};
+      Object.keys(obj).forEach((key) => {
+        if (typeof obj[key] === 'object') {
+          Object.keys(obj[key]).forEach((subKey) => {
+            newObj[subKey] = obj[key][subKey];
+          });
+        } else {
+          newObj[key] = obj[key];
+        }
+      });
+      return newObj;
+    });
+  }
+  return [];
+}
+


### PR DESCRIPTION
**What does this PR do?**

- Implements sidebar navigation to admin document management page

**Description of Task to be completed?**

- creates table displaying list of documents

- adds sorts feature by document attributes

- adds delete and edit options on documents

**How should this be manually tested?**

- install the application locally and run: `npm run start:server`

- navigate to `http://localhost:8080`

- login as the admin to view the document management link on the sidebar

- admin email `john.doe@gmail.com`

- admin password `johndoes`

**Any background context you want to provide?**

- Please install postgres locally on your device and ensure the server is on

- Please run migration and setup postgres for the application to run

- run `npm run migrations` and `npm run seeds` consecutively to setup postgres database